### PR TITLE
Bugfix parsing

### DIFF
--- a/src/bib_get.hpp
+++ b/src/bib_get.hpp
@@ -3,8 +3,12 @@
 //    (See accompanying file LICENSE or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+#ifndef DBLPBIBTEX_BIB_GET_HPP
+#define DBLPBIBTEX_BIB_GET_HPP
+
 #include "core.hpp"
 #include "network.hpp"
+#include "bib_parse.hpp"
 
 #include <contrib/string_algo.hpp>
 namespace sa = string_algo;
@@ -17,16 +21,12 @@ bool download_dblp_citation(const std::string& key, bool prepend = true)
 	if (html.empty())
 		return false;
 
-	auto it = sa::find(html, '@');
-	if (it == html.end())
-		return false;
-	auto it2 = sa::find(html, '@', it+1);
-	html.erase(it2, html.end());
+	auto bibentry = extract_bibentry(html);
 
-	if (html.empty())
+	if (bibentry.empty())
 		return false;
-	std::cout << "Downloaded bibtex entry:" << std::endl << html << std::endl;
-	add_entry_to_mainbibfile(html, prepend);
+	std::cout << "Downloaded bibtex entry:" << std::endl << bibentry << std::endl;
+	add_entry_to_mainbibfile(bibentry, prepend);
 	return true;
 }
 
@@ -38,14 +38,15 @@ bool download_cryptoeprint_citation(const std::string& key, bool prepend = true)
 	auto& html = hdr_html.second;
 	if (html.empty())
 		return false;
-
 	html.erase(html.begin(), sa::ifind(html,"<pre>")+5);
 	html.erase(sa::ifind(html,"</pre>"), html.end());
 
-	if (html.empty())
+	auto bibentry = extract_bibentry(html);
+
+	if (bibentry.empty())
 		return false;
-	std::cout << "Downloaded bibtex entry:" << std::endl << html << std::endl;
-	add_entry_to_mainbibfile(html, prepend);
+	std::cout << "Downloaded bibtex entry:" << std::endl << bibentry << std::endl;
+	add_entry_to_mainbibfile(bibentry, prepend);
 	return true;
 }
 
@@ -82,3 +83,5 @@ bool download_citation(const std::string& key, bool prepend = true)
 		return search_citation_bib(key);
 	return false;
 }
+
+#endif

--- a/src/bib_parse.hpp
+++ b/src/bib_parse.hpp
@@ -54,7 +54,7 @@ std::string extract_bibentry(const std::string& str, std::string::size_type pos)
 		{
 			if (str[posbr] == '{')
 				++open_brackets;
-			else if (str[posbr] == '{')
+			else if (str[posbr] == '}')
 				if (--open_brackets == 0)
 					break;
 		}

--- a/src/bib_parse.hpp
+++ b/src/bib_parse.hpp
@@ -1,0 +1,82 @@
+//          Copyright Marc Stevens 2010 - 2019.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef DBLPBIBTEX_BIB_PARSE_HPP
+#define DBLPBIBTEX_BIB_PARSE_HPP
+
+#include <string>
+
+#include <contrib/string_algo.hpp>
+namespace sa = string_algo;
+
+// finds starting position of the next bib-entry in bibstr
+std::string::size_type str_findbibentry(const std::string& bibstr, std::string::size_type offset = 0)
+{
+	const auto npos = std::string::npos;
+	while (true) {
+		auto pos = bibstr.find('@', offset);
+		if (pos == npos) return npos;
+		auto pos2 = bibstr.find_first_of("{(", pos);
+		if (pos2 == npos) return npos;
+		std::string cittype = sa::trim_copy(sa::to_lower_copy(bibstr.substr(pos + 1, pos2 - pos - 1)));
+		if (cittype == "article" || cittype == "book" || cittype == "booklet"
+			|| cittype == "inbook" || cittype == "incollection" || cittype == "inproceedings"
+			|| cittype == "manual" || cittype == "mastersthesis" || cittype == "misc"
+			|| cittype == "phdthesis" || cittype == "proceedings" || cittype == "techreport"
+			|| cittype == "unpublished")
+			return pos;
+		offset = pos + 1;
+	}
+}
+
+// extracts first complete bib-entry from str starting at pos
+std::string extract_bibentry(const std::string& str, std::string::size_type pos)
+{
+	// check that bibentry indeed starts at pos
+	if (pos >= str.size() || str[pos] != '@')
+		return std::string();
+	// find first opening bracket
+	auto posbr = str.find_first_of("{", pos+1);
+	if (posbr > str.size())
+		return std::string();
+	// find position of closing bracket
+	int open_brackets = 1;
+	posbr = str.find_first_of("{}", posbr+1);
+	while (posbr < str.size())
+	{
+		int countslashes = 0;
+		while (str[posbr - countslashes - 1] == '\\')
+			++countslashes;
+		// if bracket is not escaped then count it
+		if ((countslashes & 1) == 0)
+		{
+			if (str[posbr] == '{')
+				++open_brackets;
+			else if (str[posbr] == '{')
+				if (--open_brackets == 0)
+					break;
+		}
+		posbr = str.find_first_of("{}", posbr + 1);
+	}
+	if (open_brackets == 0)
+		return str.substr(pos, posbr-pos+1);
+	return std::string();
+}
+
+// extracts first complete bib-entry from str if any
+std::string extract_bibentry(const std::string& str)
+{
+	std::string::size_type pos = str_findbibentry(str);
+	while (pos < str.size())
+	{
+		std::string ret = extract_bibentry(str, pos);
+		if (!ret.empty())
+			return ret;
+		pos = str_findbibentry(str, pos + 1);
+	}
+	return std::string();
+}
+
+#endif

--- a/src/bib_search.hpp
+++ b/src/bib_search.hpp
@@ -3,6 +3,9 @@
 //    (See accompanying file LICENSE or copy at
 //          http://www.boost.org/LICENSE_1_0.txt)
 
+#ifndef DBLPBIBTEX_BIB_SEARCH_HPP
+#define DBLPBIBTEX_BIB_SEARCH_HPP
+
 #include "core.hpp"
 
 #include <contrib/string_algo.hpp>
@@ -119,3 +122,4 @@ bool search_citation_cryptoeprint(const std::string& citkey)
 	return true;
 }
 
+#endif

--- a/src/dblpbibtex.cpp
+++ b/src/dblpbibtex.cpp
@@ -10,6 +10,7 @@
 #include "network.hpp"
 #include "bib_search.hpp"
 #include "bib_get.hpp"
+#include "bib_parse.hpp"
 
 #include <contrib/program_options.hpp>
 namespace po = program_options;
@@ -32,23 +33,6 @@ using namespace std;
 parameters_type params;
 
 /*** parse bibfiles ***/
-string::size_type bibfilestr_searchentry(const string& bibstr, string::size_type offset)
-{
-	while (true) {
-		string::size_type pos = bibstr.find('@', offset);
-		if (pos == string::npos) return string::npos;
-		string::size_type pos2 = bibstr.find_first_of("{(", pos);
-		if (pos2 == string::npos) return string::npos;
-		string cittype = sa::trim_copy(sa::to_lower_copy(bibstr.substr(pos+1, pos2-pos-1)));
-		if (cittype == "article" || cittype == "book" || cittype == "booklet"
-		    || cittype == "inbook" || cittype == "incollection" || cittype == "inproceedings"
-		    || cittype == "manual" || cittype == "mastersthesis" || cittype == "misc"
-		    || cittype == "phdthesis" || cittype == "proceedings" || cittype == "techreport"
-		    || cittype == "unpublished")
-			return pos;
-		offset = pos+1;
-	}
-}
 void parse_bibfile(const string& bibfile, bool verbose = true)
 {
 	if (mainbibfile.empty())
@@ -77,9 +61,9 @@ void parse_bibfile(const string& bibfile, bool verbose = true)
 	}
 	/* find all citations */
 	string::size_type pos2;
-	pos = bibfilestr_searchentry(bibstr, 0);
+	pos = str_findbibentry(bibstr, 0);
 	while (pos < bibstr.length()) {
-		pos2 = bibfilestr_searchentry(bibstr, pos+1);
+		pos2 = str_findbibentry(bibstr, pos+1);
 		string entry = sa::trim_copy(bibstr.substr(pos, (pos2==string::npos ? pos2 : pos2-pos) ));
 		string key = entry.substr(entry.find_first_of("{(")+1);
 		sa::to_lower(entry);

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,7 @@ function cleanup
 function make_tex_doc
 {
 echo "\documentclass{article}" > test.tex
+echo "\usepackage{url}" >> test.tex
 echo "\begin{document}" >> test.tex
 while [ "$1" != "" ]; do
 	echo "\cite{$1}" >> test.tex
@@ -28,16 +29,16 @@ make_tex_doc $*
 touch test.bib
 
 pdflatex test &> pdflatex1.log
-../dblpbibtex test |& tee -a dblpbibtex.log
-echo "=== test.tex ==="
-cat test.tex
-echo "================"
-echo "=== test.bib ==="
-cat test.bib
-echo "================"
+../dblpbibtex test &>> dblpbibtex.log
+#echo "=== test.tex ==="
+#cat test.tex
+#echo "================"
+#echo "=== test.bib ==="
+#cat test.bib
+#echo "================"
 
 pdflatex test &> pdflatex2.log
-../dblpbibtex test |& tee -a dblpbibtex.log
+../dblpbibtex test &>> dblpbibtex.log
 echo "=== test.tex ==="
 cat test.tex
 echo "================"
@@ -48,6 +49,7 @@ echo "================"
 }
 
 rm test.log
-#test_bib_download "cryptoeprint:2017:190"
-#test_bib_download "DBLP:conf/crypto/StevensBKAM17"
+test_bib_download "cryptoeprint:2017:190"
+test_bib_download "DBLP:conf/crypto/StevensBKAM17"
 test_bib_download "dblpbibtex:enablesearch" "search-cryptoeprint:stevens+karpman"
+test_bib_download "DBLP:conf/icfp/HamanaF11"

--- a/vs2017/dblpbibtex.vcxproj
+++ b/vs2017/dblpbibtex.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\bib_get.hpp" />
+    <ClInclude Include="..\src\bib_parse.hpp" />
     <ClInclude Include="..\src\bib_search.hpp" />
     <ClInclude Include="..\src\core.hpp" />
     <ClInclude Include="..\src\network.hpp" />

--- a/vs2017/dblpbibtex.vcxproj.filters
+++ b/vs2017/dblpbibtex.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClInclude Include="..\src\network.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\bib_parse.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\dblpbibtex.cpp">


### PR DESCRIPTION
Fixes issue #11 

Instead of simply parsing a DBLP bib-entry till the next `@` symbol,
do the right thing and find the correct `}` bracket that ends the bib-entry.