### PR TITLE
Dockerfile addition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:stable
+
+
+# environment variables and arguments
+ENV SOURCE_URL https://github.com/cr-marcstevens/dblpbibtex
+ENV WORKDIR /workdir
+ARG UID 1000
+ARG GUID 1000
+
+
+
+# install compilation dependencies
+RUN apt-get update && apt-get install -y -q --no-install-recommends libboost-dev git build-essential dh-autoreconf libcurl4-gnutls-dev texlive
+
+# reinstall certificates (to avoid further errors)
+RUN apt-get install --reinstall ca-certificates -y
+
+
+# clone repository
+RUN cd /tmp && git clone $SOURCE_URL
+
+# compile and install dblpbibtex
+RUN cd /tmp/dblpbibtex && autoreconf --install && ./configure && make && make install
+
+
+# set the working directory
+WORKDIR $WORKDIR
+
+# switch user
+USER ${UID}:${GUID}
+
+


### PR DESCRIPTION
This pull request adds a Dockerfile to build an image of dblpbibtex.

I've built and pushed the image on [Docker hub](https://github.com/cr-marcstevens/dblpbibtex). 

Let me know if you want to provide a pre-built image yourself and thus edit the README with instructions on how to use the tool with Docker. With my image using `dblpbibtex` would look like this

```bash
/usr/bin/docker run -it --volume=$(pwd):/workdir --user=$(id -u):$(id -g) wichtf/dblpbibtex:latest dblpbibtex
```

